### PR TITLE
Change http and native remote default addresses.

### DIFF
--- a/EmbeddedWildFlyLauncher.java
+++ b/EmbeddedWildFlyLauncher.java
@@ -1,0 +1,257 @@
+package org.jboss.errai.cdi.server.gwt;
+
+import java.io.*;
+import java.net.BindException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.as.embedded.EmbeddedServerFactory;
+import org.jboss.as.embedded.StandaloneServer;
+import org.jboss.errai.cdi.server.as.JBossServletContainerAdaptor;
+import org.jboss.errai.cdi.server.gwt.util.JBossUtil;
+import org.jboss.errai.cdi.server.gwt.util.StackTreeLogger;
+
+import com.google.gwt.core.ext.ServletContainer;
+import com.google.gwt.core.ext.ServletContainerLauncher;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.TreeLogger.Type;
+import com.google.gwt.core.ext.UnableToCompleteException;
+
+/**
+ * A {@link ServletContainerLauncher} controlling an embedded WildFly instance.
+ * 
+ * This launcher will add exclusions for client-side classes to the project's
+ * beans.xml. These classes are not needed on the server and are going to cause
+ * class loading issues if deployed (i.e. because they reference GWT classes
+ * that are not present at runtime). By default, classes in packages under
+ * /client/local will be considered client-side but this can be configured using
+ * the system property errai.client.local.class.pattern. Existing exclusions
+ * will stay intact. If no beans.xml is present, a new one will be created.
+ * 
+ * @author Christian Sadilek <christian.sadilek@gmail.com>
+ */
+public class EmbeddedWildFlyLauncher extends ServletContainerLauncher {
+  private static final String CLIENT_LOCAL_CLASS_PATTERN_PROPERTY = "errai.client.local.class.pattern";
+  private static final String DEFAULT_CLIENT_LOCAL_CLASS_PATTERN = ".*/client/local/.*";
+  
+  private static final String ERRAI_SCANNER_HINT_START = 
+          "\n    <!-- These exclusions were added by Errai to avoid deploying client-side classes to the server -->\n";
+  private static final String ERRAI_SCANNER_HINT_END = 
+          "    <!-- End of Errai exclusions -->\n";
+  
+  private static final String DEVMODE_BEANS_XML_TEMPLATE = 
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<beans xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\">\n" + 
+          "  <scan>" +
+          "$EXCLUSIONS" +
+          "  </scan>\n" + 
+       "</beans>";
+  
+  private static final String DEVMODE_BEANS_XML_EXCLUSION_TEMPLATE = "    <exclude name = \"$CLASSNAME\" />\n";
+  
+  private static final String ERRAI_PROPERTIES_HINT_START = "#Errai-Start\n";
+  private static final String ERRAI_PROPERTIES_HINT_END = "\n#Errai-End\n";
+  private static final String ERRAI_PROPERTIES_REALM_TOKEN = "\n#$REALM_NAME=ApplicationRealm$ This line is used by " +
+          "the add-user utility to identify the realm name already used in this file.\n";
+
+  static {
+    System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+  }
+  
+  private StackTreeLogger logger;
+  
+  @Override
+  public ServletContainer start(final TreeLogger treeLogger, final int port, final File appRootDir) throws BindException, Exception {
+    logger = new StackTreeLogger(treeLogger);
+    try {
+      System.setProperty("jboss.http.port", "" + port);
+      
+      final String jbossHome = JBossUtil.getJBossHome(logger);
+      final StandaloneServer embeddedWildFly = EmbeddedServerFactory.create(jbossHome, null, null);
+      embeddedWildFly.start();
+      
+      prepareBeansXml(appRootDir);
+      prepareUsersAndRoles(jbossHome);
+      JBossServletContainerAdaptor controller = new JBossServletContainerAdaptor(port, appRootDir, 
+              JBossUtil.getDeploymentContext(), logger.peek(), null);
+      
+      return controller;
+    }
+    catch (UnableToCompleteException e) {
+      logger.log(Type.ERROR, "Could not start servlet container controller", e);
+      throw new UnableToCompleteException();
+    }
+  }
+  
+  /**
+   * Reads application-users.properties and application-roles.properties from
+   * the classpath and amends the corresponding files under
+   * standalone/configuration. This allows applications to specify users and
+   * roles for development mode.
+   */
+  private void prepareUsersAndRoles(final String jbossHome) {
+    InputStream usersStream = 
+            Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.USERS_PROPERTY_FILE);
+    
+    if (usersStream != null) {
+      processPropertiesFile(JBossUtil.USERS_PROPERTY_FILE, jbossHome, usersStream, true);
+    }
+    
+    InputStream rolesStream = 
+            Thread.currentThread().getContextClassLoader().getResourceAsStream(JBossUtil.ROLES_PROPERTY_FILE);
+    
+    if (rolesStream != null) {
+      processPropertiesFile(JBossUtil.ROLES_PROPERTY_FILE, jbossHome, rolesStream, false);
+    }
+  }
+
+  private void processPropertiesFile(final String propertyFileName, final String jbossHome,
+                                           final InputStream newUsersStream, final boolean handleRealmToken) {
+    final File propertyDir = new File(jbossHome, JBossUtil.STANDALONE_CONFIGURATION);
+    final File propertyFile = new File(propertyDir, propertyFileName);
+
+    try {
+
+      String realmToken = ERRAI_PROPERTIES_REALM_TOKEN;
+      boolean isErraiContent = false;
+      final StringBuilder result = new StringBuilder();
+      List<String> lines = FileUtils.readLines(propertyFile);
+      if (lines != null) {
+
+        for (final String currentLine : lines) {
+          String trimmed = currentLine.trim();
+          if(trimmed.startsWith(ERRAI_PROPERTIES_HINT_START.trim())) {
+            isErraiContent = true;
+          } else if(trimmed.startsWith(ERRAI_PROPERTIES_HINT_END.trim())) {
+            isErraiContent = false;
+          } else if(handleRealmToken && trimmed.startsWith("#") && trimmed.contains("$REALM_NAME=")) {
+            realmToken = currentLine;
+          } else if (!isErraiContent) {
+            result.append(currentLine).append("\n");
+          }
+        }
+
+        final String newUsersStr = IOUtils.toString(newUsersStream, (String) null);
+        result.append(ERRAI_PROPERTIES_HINT_START);
+        result.append(newUsersStr).append("\n");
+        result.append(ERRAI_PROPERTIES_HINT_END);
+
+        if (handleRealmToken) {
+          result.append(realmToken).append("\n");
+        }
+
+        try {
+          FileUtils.write(propertyFile, result.toString());
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to write content for " +
+                  propertyFileName + " in " + propertyFile.getAbsolutePath(), e);
+        }
+      }
+
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to parse content for " +
+              propertyFileName + " in " + propertyFile.getAbsolutePath(), e);
+    }
+
+  }
+
+
+
+  /**
+   * Writes a new or updates an existing beans.xml file to add exclusions for
+   * client-only classes. We do this to avoid class loading problems on
+   * deployment.
+   * 
+   * @param appRootDir
+   *          the root application directory (configured as <hostedWebapp> when
+   *          using the gwt-maven-plugin).
+   * @throws IOException
+   */
+  private void prepareBeansXml(File appRootDir) throws IOException {
+    File webInfDir = new File(appRootDir, "WEB-INF");
+    File classesDir = new File(webInfDir, "classes");
+    
+    StringBuilder exclusions = new StringBuilder();
+    exclusions.append(ERRAI_SCANNER_HINT_START);
+    for (File clientLocalClass : FileUtils.listFiles(appRootDir, new ClientLocalFileFilter(), TrueFileFilter.INSTANCE)) {
+      final String className = clientLocalClass.getAbsolutePath();
+      if (className.endsWith(".class")) {
+        String exclusion = className
+          .replace(classesDir.getAbsolutePath(), "")
+          .replace(".class", "")
+          .replace(File.separator, ".")
+          .substring(1);
+        exclusions.append(DEVMODE_BEANS_XML_EXCLUSION_TEMPLATE.replace("$CLASSNAME", exclusion));
+      }
+    }
+    exclusions.append(ERRAI_SCANNER_HINT_END);
+    
+    File beansXml = new File(webInfDir, "beans.xml");
+    String beansXmlContent;
+    if (!beansXml.exists()) {
+      beansXmlContent = DEVMODE_BEANS_XML_TEMPLATE.replace("$EXCLUSIONS", exclusions.toString());
+    }
+    else {
+      beansXmlContent = FileUtils.readFileToString(beansXml);
+      beansXmlContent = removeExistingErraiExclusions(beansXmlContent);
+      if (beansXmlContent.contains(exclusions)) 
+        return;
+      
+      if (beansXmlContent.contains("<scan>")) {
+        beansXmlContent = beansXmlContent.replace("<scan>", "<scan>" + exclusions);
+      }
+      else {
+        beansXmlContent = beansXmlContent.replace("</beans>", "  <scan>" + exclusions + "  </scan>\n</beans>");
+      }
+      validateBeansXml(beansXmlContent);
+    }
+    FileUtils.write(beansXml, beansXmlContent);
+  }
+  
+  private void validateBeansXml(String beansXmlContent) {
+    if (beansXmlContent.contains("beans_1_0.xsd")) {
+      logger.log(Type.WARN, "Your beans.xml file doesn't not allow for CDI 1.1! "
+              + "Please remove the CDI 1.0 XML Schema.");
+    }
+  }
+  
+  private String removeExistingErraiExclusions(String beansXmlContent) {
+    String oldExclusions = StringUtils.substringBetween(beansXmlContent, 
+            ERRAI_SCANNER_HINT_START, ERRAI_SCANNER_HINT_END);
+    
+    beansXmlContent = beansXmlContent.replace(ERRAI_SCANNER_HINT_START, "");
+    if (oldExclusions != null) {
+      beansXmlContent = beansXmlContent.replace(oldExclusions, "");
+    }
+    beansXmlContent = beansXmlContent.replace(ERRAI_SCANNER_HINT_END, "");
+    
+    return beansXmlContent;
+  }
+  
+  private class ClientLocalFileFilter implements IOFileFilter {
+    final String clientLocalClassPatternString = 
+            System.getProperty(CLIENT_LOCAL_CLASS_PATTERN_PROPERTY, DEFAULT_CLIENT_LOCAL_CLASS_PATTERN);
+    
+    final Pattern clientLocalClassPattern = Pattern.compile(clientLocalClassPatternString);
+    
+    @Override
+    public boolean accept(File pathName) {
+      return accept(pathName.getAbsolutePath());
+    }
+
+    @Override
+    public boolean accept(File dir, String file) {
+      String fullName = dir.getAbsolutePath() + File.separator + file;
+      return accept(fullName);
+    }
+    
+    private boolean accept(String fileName) {
+      return clientLocalClassPattern.matcher(fileName).matches();
+    }
+  }
+}

--- a/JBossServletContainerAdaptor.java
+++ b/JBossServletContainerAdaptor.java
@@ -1,0 +1,334 @@
+package org.jboss.errai.cdi.server.as;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jboss.as.cli.CliInitializationException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.errai.cdi.server.gwt.util.StackTreeLogger;
+
+import com.google.gwt.core.ext.ServletContainer;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.TreeLogger.Type;
+import com.google.gwt.core.ext.UnableToCompleteException;
+
+/**
+ * Acts as a an adaptor between gwt's ServletContainer interface and a JBoss
+ * AS/WildFly instance.
+ *
+ * @author Max Barkley <mbarkley@redhat.com>
+ * @author Christian Sadilek <csadilek@redhat.com>
+ */
+public class JBossServletContainerAdaptor extends ServletContainer {
+
+  private final CommandContext ctx;
+
+  private final int port;
+  private final StackTreeLogger logger;
+  private final String context;
+  @SuppressWarnings("unused")
+  private final Process jbossProcess;
+
+  private static String NATIVE_CONTROLLER_PATH = "remote://localhost:9999";
+  private static String HTTP_CONTROLLER_PATH = "http-remoting://localhost:9990";
+  private static final int MAX_RETRIES = 9;
+
+  /**
+   * Initialize the command context for a remote JBoss AS instance.
+   *
+   * @param port
+   *          The port to which the JBoss instance binds.
+   * @param appRootDir
+   *          The exploded war directory to be deployed.
+   * @param context
+   *          The deployment context for the app.
+   * @param treeLogger
+   *          For logging events from this container.
+   * @throws UnableToCompleteException
+   *           Thrown if this container cannot properly connect or deploy.
+   */
+  
+  public JBossServletContainerAdaptor(int port, File appRootDir, String context, TreeLogger treeLogger,
+          Process jbossProcess) throws UnableToCompleteException {
+	  this(port,appRootDir,context,treeLogger,jbossProcess,null, null);
+  }
+  
+  /**
+   * Initialize the command context for a remote JBoss AS instance.
+   *
+   * @param port
+   *          The port to which the JBoss instance binds.
+   * @param appRootDir
+   *          The exploded war directory to be deployed.
+   * @param context
+   *          The deployment context for the app.
+   * @param treeLogger
+   *          For logging events from this container.
+   * @param httpRemotingAddress
+   * 		  If not null, overrides HTTP_CONTROLLER_PATH property with the specified one.
+   * @param nativeRemotingAddress
+   * 		  If not null, overrides NATIVE_CONTROLLER_PATH property with the specified one.
+   * 
+   * @throws UnableToCompleteException
+   *           Thrown if this container cannot properly connect or deploy.
+   */
+  public JBossServletContainerAdaptor(int port, File appRootDir, String context, TreeLogger treeLogger,
+          Process jbossProcess,String httpRemotingAddress, String nativeRemotingAddress ) throws UnableToCompleteException {
+    this.port = port;
+    logger = new StackTreeLogger(treeLogger);
+    this.jbossProcess = jbossProcess;
+    this.context = context;
+    
+    logger.branch(Type.INFO, "Starting container initialization...");
+    // Overrides remoting address if and only if an ovverride is passed.
+    if(httpRemotingAddress != null && !httpRemotingAddress.trim().equalsIgnoreCase(HTTP_CONTROLLER_PATH)) {
+    	logger.branch(Type.INFO, "Changing default HTTP_CONTROLLER_PATH property from ["+HTTP_CONTROLLER_PATH+"] to ["+httpRemotingAddress+"]");
+    	HTTP_CONTROLLER_PATH = httpRemotingAddress;
+    }
+
+    if(nativeRemotingAddress != null && !nativeRemotingAddress.trim().equalsIgnoreCase(NATIVE_CONTROLLER_PATH)) {
+    	logger.branch(Type.INFO, "Changing default NATIVE_CONTROLLER_PATH property from ["+NATIVE_CONTROLLER_PATH+"] to ["+nativeRemotingAddress+"]");
+    	NATIVE_CONTROLLER_PATH = nativeRemotingAddress;
+    }
+
+    
+    CommandContext ctx = null;
+    try {
+      // Create command context
+      try {
+
+        logger.branch(Type.INFO, "Creating new command context...");
+        ctx = CommandContextFactory.getInstance().newCommandContext();
+        this.ctx = ctx;
+
+        logger.log(Type.INFO, "Command context created");
+        logger.unbranch();
+      }
+      catch (CliInitializationException e) {
+        logger.branch(TreeLogger.Type.ERROR, "Could not initialize JBoss AS command context", e);
+        throw new UnableToCompleteException();
+      }
+
+      attemptCommandContextConnection(MAX_RETRIES);
+
+      try {
+        // Undeploy the app in case the container/devmode wasn't shutdown correctly which should
+        // have removed the deployment (see stop method).
+        removeDeployment();
+        
+        /*
+         * Need to add deployment resource to specify exploded archive
+         *
+         * path : the absolute path the deployment file/directory archive : true
+         * iff the an archived file, false iff an exploded archive enabled :
+         * true iff war should be automatically scanned and deployed
+         */
+        logger.branch(Type.INFO,
+                String.format("Adding deployment %s at %s...", getAppName(), appRootDir.getAbsolutePath()));
+
+        final ModelNode operation = getAddOperation(appRootDir.getAbsolutePath());
+        final ModelNode result = ctx.getModelControllerClient().execute(operation);
+        if (!Operations.isSuccessfulOutcome(result)) {
+          logger.log(Type.ERROR, String.format("Could not add deployment:\nInput:\n%s\nOutput:\n%s",
+                  operation.toJSONString(false), result.toJSONString(false)));
+          throw new UnableToCompleteException();
+        }
+
+        logger.log(Type.INFO, "Deployment resource added");
+        logger.unbranch();
+      }
+      catch (IOException e) {
+        logger.branch(Type.ERROR, String.format("Could not add deployment %s", getAppName()), e);
+        throw new UnableToCompleteException();
+      }
+
+      attemptDeploy();
+
+    }
+    catch (UnableToCompleteException e) {
+      logger.branch(Type.INFO, "Attempting to stop container...");
+      stopHelper();
+
+      throw e;
+    }
+
+  }
+
+  @Override
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public void refresh() throws UnableToCompleteException {
+    attemptDeploymentRelatedOp(ClientConstants.DEPLOYMENT_REDEPLOY_OPERATION);
+  }
+
+  @Override
+  public void stop() throws UnableToCompleteException {
+    try {
+      logger.branch(Type.INFO, String.format("Removing %s from deployments...", getAppName()));
+
+      ModelNode result = removeDeployment();
+      if (!Operations.isSuccessfulOutcome(result)) {
+        logger.log(
+                Type.ERROR,
+                String.format("Could not undeploy AS:\nInput:\n%s\nOutput:\n%s", getAppName(),
+                        result.toJSONString(false)));
+        throw new UnableToCompleteException();
+      }
+
+      logger.log(Type.INFO, String.format("%s removed", getAppName()));
+      logger.unbranch();
+    }
+    catch (IOException e) {
+      logger.log(Type.ERROR, "Could not shutdown AS", e);
+      throw new UnableToCompleteException();
+    }
+    finally {
+      stopHelper();
+    }
+  }
+
+  private ModelNode removeDeployment() throws IOException {
+    final ModelNode operation = Operations.createRemoveOperation(
+            new ModelNode().add(ClientConstants.DEPLOYMENT, getAppName()));
+    return ctx.getModelControllerClient().execute(operation);
+  }
+  
+  private void attemptCommandContextConnection(final int maxRetries)
+          throws UnableToCompleteException {
+
+    String[] controllers = new String[] { HTTP_CONTROLLER_PATH,  NATIVE_CONTROLLER_PATH  };
+    
+    final String[] protocols = new String[controllers.length];
+    for (int i = 0; i < controllers.length; i++) {
+      protocols[i] = controllers[i].split(":", 2)[0];
+    }
+
+    for (int retry = 0; retry < maxRetries; retry++) {
+      for (int i = 0; i < controllers.length; i++) {
+        final String controller = controllers[i];
+        final String protocol = protocols[i];
+        try {
+          logger.branch(Type.INFO, String.format("Attempting to connect with %s protocol.", protocol));
+          ctx.connectController(controller);
+          logger.log(Type.INFO, "Connected to JBoss AS");
+
+          return;
+        }
+        catch (CommandLineException e) {
+          logger.log(
+                  Type.INFO,
+                  String.format("Attempt %d failed at connecting with %s protocol", retry + 1, protocol),
+                  e);
+        }
+        finally {
+          logger.unbranch();
+        }
+      }
+
+      // No connection attempts have succeeded, so wait a bit before trying
+      // again.
+      if (retry < maxRetries) {
+        try {
+          Thread.sleep(1000);
+        }
+        catch (InterruptedException e1) {
+          logger.log(Type.WARN, "Thread was interrupted while waiting for AS to reload", e1);
+        }
+      }
+    }
+
+    logger.log(Type.ERROR, "Could not connect to AS");
+    throw new UnableToCompleteException();
+  }
+
+  private void stopHelper() {
+    logger.branch(Type.INFO, "Attempting to stop JBoss AS instance...");
+    /*
+     * There is a problem with Process#destroy where it will not reliably kill
+     * the JBoss instance. So instead we must try and send a shutdown signal. If
+     * that is not possible or does not work, we will log it's failure, advising
+     * the user to manually kill this process.
+     */
+    try {
+      if (ctx.getControllerHost() == null) {
+        ctx.handle("connect localhost:9999");
+      }
+      ctx.handle(":shutdown");
+
+      logger.log(Type.INFO, "JBoss AS instance stopped");
+      logger.unbranch();
+    }
+    catch (CommandLineException e) {
+      logger.log(Type.ERROR, "Could not shutdown JBoss AS instance. "
+              + "Restarting this container while a JBoss AS instance is still running will cause errors.");
+    }
+
+    logger.branch(Type.INFO, "Terminating command context...");
+    ctx.terminateSession();
+    logger.log(Type.INFO, "Command context terminated");
+    logger.unbranch();
+  }
+
+  private void attemptDeploy() throws UnableToCompleteException {
+    attemptDeploymentRelatedOp(ClientConstants.DEPLOYMENT_DEPLOY_OPERATION);
+  }
+
+  private void attemptDeploymentRelatedOp(final String opName) throws UnableToCompleteException {
+    try {
+      logger.branch(Type.INFO, String.format("Deploying %s...", getAppName()));
+
+      final ModelNode operation = Operations.createOperation(opName,
+              new ModelNode().add(ClientConstants.DEPLOYMENT, getAppName()));
+      final ModelNode result = ctx.getModelControllerClient().execute(operation);
+
+      if (!Operations.isSuccessfulOutcome(result)) {
+        logger.log(
+                Type.ERROR,
+                String.format("Could not %s %s:\nInput:\n%s\nOutput:\n%s", opName, getAppName(),
+                        operation.toJSONString(false), result.toJSONString(false)));
+        throw new UnableToCompleteException();
+      }
+
+      logger.log(Type.INFO, String.format("%s %sed", getAppName(), opName));
+      logger.unbranch();
+    }
+    catch (IOException e) {
+      logger.branch(Type.ERROR, String.format("Could not %s %s", opName, getAppName()), e);
+      throw new UnableToCompleteException();
+    }
+  }
+
+  /**
+   * @return The runtime-name for the given deployment.
+   */
+  private String getAppName() {
+    // Deployment names must end with .war
+    return context.endsWith(".war") ? context : context + ".war";
+  }
+
+  private ModelNode getAddOperation(String path) {
+    final ModelNode command = Operations.createAddOperation(new ModelNode().add(ClientConstants.DEPLOYMENT,
+            getAppName()));
+    final ModelNode content = new ModelNode();
+    final ModelNode contentObj = new ModelNode();
+
+    // Construct content list
+    contentObj.get("path").set(path);
+    contentObj.get("archive").set(false);
+    content.add(contentObj);
+
+    command.get("content").set(content);
+    command.get("enabled").set(false);
+
+    return command;
+  }
+  
+}


### PR DESCRIPTION
Added two properties ("errai.jboss.httpremotingaddress" and "errai.jboss.nativeremotingaddress" to override defaults used by JBoss launcher), I think that may be useful if WildFly needs to be bound on different ports with respect to 9990.
